### PR TITLE
Update broken nav link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
           </span>
           <ul class="p-navigation__links">
             <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices" class="p-link--external">GitHub repo</a></li>
-            <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external">How to contribute</a></li>
+            <li class="p-navigation__link"><a href="https://github.com/canonical-web-and-design/practices/blob/master/CONTRIBUTING.md" class="p-link--external">How to contribute</a></li>
           </ul>
         </nav>
       </header>


### PR DESCRIPTION
## Done
- Broken link update on 'How to contribute' 👍 

## QA
- Run `jekyll serve`
- Go to `http://127.0.0.1:4000/practices/`
- Click 'How to contribute' item in the navigation
- See that it points to https://github.com/canonical-web-and-design/practices/blob/master/CONTRIBUTING.md