### PR TITLE
Recommend Stylelint to lint Sass files

### DIFF
--- a/coding/stylesheets.md
+++ b/coding/stylesheets.md
@@ -201,6 +201,10 @@ developer working with JavaScript, leave these well alone.
 The idea is that -- in order to properly separate our concerns, we
 should never have styling and behaviour bound to the same classes.
 
-# Code Formatting
+## Code Formatting
 
 To ensure consistency across our codebase, we use [Prettier](https://github.com/prettier/prettier) for formatting Sass.
+
+## Stylesheet Linting
+
+To ensure conformity and correctness in Sass files across our codebase, we use [Stylelint](https://stylelint.io/) to lint our Sass files. We use the [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended) shared configuration as it plays nicely with Prettier.


### PR DESCRIPTION
Historically, we've used `scss-lint` and latterly `sass-lint` to lint Sass files. These have now both fell by the wayside to be superseded by Stylelint which is built with React, Prettier et al in mind.

We already have Prettier, why do we need this? Prettier is only concerned with style, Stylelint is concerned with correctness and will flag issues which could cause bugs and code smells such as duplicate rules in the same scope, excessive nesting etc.

Thoughts?