### PR TITLE
Don't call it BEM

### DIFF
--- a/coding/stylesheets.md
+++ b/coding/stylesheets.md
@@ -3,7 +3,6 @@ title: Stylesheet coding standards
 description: Code style standards for CSS and Sass
 ---
 
-
 Our stylesheet conding standard is based on [BEM methodology](http://getbem.com/).
 
 All class names in the codebase are built of three parts:

--- a/coding/stylesheets.md
+++ b/coding/stylesheets.md
@@ -1,5 +1,5 @@
 ---
-title: Stylesheets coding standard
+title: Stylesheet coding standards
 description: Code style standards for CSS and Sass
 ---
 

--- a/coding/stylesheets.md
+++ b/coding/stylesheets.md
@@ -3,22 +3,18 @@ title: Stylesheet coding standards
 description: Code style standards for CSS and Sass
 ---
 
-## BEM methodology
 
 Our stylesheet conding standard is based on [BEM methodology](http://getbem.com/).
 
-For a quick recap on BEM, it works by breaking down all classes in a
-codebase into one of three groups:
+All class names in the codebase are built of three parts:
 
 - Block: The sole root of the component.
-
 - Element: A component part of the Block.
-
-- Modifier: A variant or extension of the Block.
+- Modifier: A variant or extension of the Block or Element.
 
 The point of BEM is to give a lot more transparency and clarity to your
-markup. BEM informs developers how classes relate to each other, which
-is particularly useful in complex or deep pieces of DOM.
+markup. This naming structure informs developers how classes relate to each other,
+which is particularly useful in complex or deep pieces of DOM.
 
 There are a number of common problems when working with CSS at scale,
 but the major two that this document aims to solve are clarity and

--- a/coding/stylesheets.md
+++ b/coding/stylesheets.md
@@ -1,7 +1,11 @@
 ---
-title: BEM coding standard
+title: Stylesheets coding standard
 description: Code style standards for CSS and Sass
 ---
+
+## BEM methodology
+
+Our stylesheet conding standard is based on [BEM methodology](http://getbem.com/).
 
 For a quick recap on BEM, it works by breaking down all classes in a
 codebase into one of three groups:


### PR DESCRIPTION
We call our stylesheet guidelines "BEM" (in the title), when strictly speaking we don't use BEM, only "BEM-inspired" naming convention.

This PR updates the title to not call the document "BEM standards", because our standards are not BEM.

